### PR TITLE
fix: support for windows

### DIFF
--- a/scripts/tools/copyPackageSet.ts
+++ b/scripts/tools/copyPackageSet.ts
@@ -13,9 +13,9 @@ export const copyPackageSet = async (): Promise<void> => {
   const libDir = "lib";
   const publishPackageJson = path.join(libDir, "package.json");
   pkg.private = undefined;
-  pkg.main = path.relative(libDir, pkg.main);
-  pkg.module = path.relative(libDir, pkg.module);
-  pkg.types = path.relative(libDir, pkg.types);
+  pkg.main = path.posix.relative(libDir, pkg.main);
+  pkg.module = path.posix.relative(libDir, pkg.module);
+  pkg.types = path.posix.relative(libDir, pkg.types);
   pkg.directories = undefined;
   pkg.files = undefined;
   fs.writeFileSync(publishPackageJson, JSON.stringify(pkg, null, 2), {

--- a/src/Converter/v3/TypeNodeContext.ts
+++ b/src/Converter/v3/TypeNodeContext.ts
@@ -16,8 +16,8 @@ export interface ReferencePathSet {
 const generatePath = (entryPoint: string, currentPoint: string, referencePath: string): ReferencePathSet => {
   const ext = Path.extname(currentPoint); // .yml
   const from = Path.relative(Path.dirname(entryPoint), currentPoint).replace(ext, ""); // components/schemas/A/B
-  const base = Path.dirname(from);
-  const result = Path.relative(base, referencePath); // remoteの場合? localの場合 referencePath.split("/")
+  const base = Path.dirname(from).replace(Path.sep, "/");
+  const result = Path.posix.relative(base, referencePath); // remoteの場合? localの場合 referencePath.split("/")
   const pathArray = result.split("/");
   return {
     pathArray,
@@ -29,7 +29,7 @@ const calculateReferencePath = (store: Store.Type, base: string, pathArray: stri
   let names: string[] = [];
   let unresolvedPaths: string[] = [];
   pathArray.reduce((previous, lastPath, index) => {
-    const current = Path.join(previous, lastPath);
+    const current = Path.posix.join(previous, lastPath);
     // ディレクトリが深い場合は相対パスが`..`を繰り返す可能性があり、
     // その場合はすでに登録されたnamesを削除する
     if (lastPath === ".." && names.length > 0) {

--- a/src/Converter/v3/components/Reference.ts
+++ b/src/Converter/v3/components/Reference.ts
@@ -100,7 +100,7 @@ export const generateLocalReference = (reference: OpenApi.Reference): LocalRefer
     return;
   }
   const name = reference.$ref.split(localReferencePattern)[1];
-  const localPath = path.join(localReferenceComponents[localReferencePattern], name);
+  const localPath = path.posix.join(localReferenceComponents[localReferencePattern], name);
   if (!localPath.startsWith("components")) {
     throw new DevelopmentError(`localPath is not start "components":\n${localPath}`);
   }
@@ -138,7 +138,7 @@ export const generate = <T>(entryPoint: string, currentPoint: string, reference:
 
   const relativePathFromEntryPoint = path.relative(path.dirname(entryPoint), referencePoint); // components/hoge/fuga.yml
   const ext = path.extname(relativePathFromEntryPoint); // .yml
-  const pathArray: string[] = relativePathFromEntryPoint.replace(ext, "").split("/"); // ["components", "hoge", "fuga"]
+  const pathArray: string[] = relativePathFromEntryPoint.replace(ext, "").split(path.sep); // ["components", "hoge", "fuga"]
   const targetPath: string = pathArray.join("/"); // components/hoge/fuga
   const schemaName = pathArray[pathArray.length - 1]; // fuga
   const componentName = pathArray[0] === "components" ? pathArray[1] : "";

--- a/src/Converter/v3/components/Response.ts
+++ b/src/Converter/v3/components/Response.ts
@@ -77,7 +77,7 @@ export const generateReferenceNamespace = (
     kind: "namespace",
     name: nameWithStatusCode,
   });
-  const headerNamespace = store.getStatement(path.join(responseReference.path, "Header"), "namespace");
+  const headerNamespace = store.getStatement(path.posix.join(responseReference.path, "Header"), "namespace");
   if (headerNamespace) {
     store.addStatement(`${basePath}/Header`, {
       kind: "namespace",

--- a/src/Converter/v3/components/Responses.ts
+++ b/src/Converter/v3/components/Responses.ts
@@ -41,7 +41,7 @@ export const generateNamespace = (
           reference.referencePoint,
           store,
           factory,
-          path.dirname(reference.path), // referencePoint basename === namespace name
+          path.posix.dirname(reference.path), // referencePoint basename === namespace name
           reference.name,
           reference.data,
           context,
@@ -94,7 +94,7 @@ export const generateNamespaceWithStatusCode = (
           reference.referencePoint,
           store,
           factory,
-          path.dirname(reference.path), // referencePoint basename === namespace name
+          path.posix.dirname(reference.path), // referencePoint basename === namespace name
           reference.name,
           reference.data,
           context,
@@ -157,7 +157,7 @@ export const generateInterfacesWithStatusCode = (
           reference.referencePoint,
           store,
           factory,
-          path.dirname(reference.path), // referencePoint basename === namespace name
+          path.posix.dirname(reference.path), // referencePoint basename === namespace name
           reference.name,
           reference.data,
           context,

--- a/src/Converter/v3/store/Store.ts
+++ b/src/Converter/v3/store/Store.ts
@@ -1,4 +1,4 @@
-import { relative } from "path";
+import * as Path from "path";
 
 import { Tree } from "@himenon/path-oriented-data-structure";
 import Dot from "dot-prop";
@@ -87,11 +87,11 @@ export const create = (factory: Factory.Type, rootDocument: OpenApi.Document): T
       if (!path.startsWith("components")) {
         throw new UnSupportError(`componentsから始まっていません。path=${path}`);
       }
-      const targetPath = relative("components", path);
+      const targetPath = Path.posix.relative("components", path);
       operator.set(targetPath, Structure.createInstance(statement));
     },
     getStatement: <T extends Structure.DataStructure.Kind>(path: string, kind: T): Structure.DataStructure.GetChild<T> | undefined => {
-      const targetPath = relative("components", path);
+      const targetPath = Path.posix.relative("components", path);
       return getChildByPaths(targetPath, kind);
     },
     getRootStatements,


### PR DESCRIPTION
## Summary

This PR solves the problem that it doesn't work in Windows environment. Fixes the problem caused by using the `path` module to resolve the path of OpenAPI.

To solve this problem, the related library needs to be fix.

depended PR: https://github.com/Himenon/path-oriented-data-structure/pull/3

## Test Plan

Works fine on my windows machine. Correctly process the Component described in the file and described in the external file.
