### PR TITLE
docs: update playground url

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -16,7 +16,7 @@ labels: "Status: Unconfirmed"
 <!--
   Write the minimum OpenAPI JSON or YAML Schema needed to reproduce the bug.
   If you can reproduce it with the following Playground, please post the URL too.
-  https://himenon.github.io/openapi-typescript-code-generator-playground/index.html
+  https://openapi-typescript-playground.netlify.app
 -->
 
 ## The current behavior

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Since the parameters extracted from OpenAPI can be used freely, it can be used f
 
 ## Playground
 
-- [Playground](https://himenon.github.io/openapi-typescript-code-generator-playground/index.html)
+- [Playground](https://openapi-typescript-playground.netlify.app)
 
 ## Installation
 

--- a/docs/ja/README-ja.md
+++ b/docs/ja/README-ja.md
@@ -6,7 +6,7 @@ OpenAPI から抽出したパラメーターは自由に使うことができる
 
 ## Playground
 
-- [Playground](https://himenon.github.io/openapi-typescript-code-generator-playground/index.html)
+- [Playground](https://openapi-typescript-playground.netlify.app)
 
 ## DEMO
 


### PR DESCRIPTION
## Summary

Because GitHub Pages has exceeded its hosting capacity.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
