### PR TITLE
Local reference parameter required

### DIFF
--- a/src/internal/OpenApiTools/components/Parameter.ts
+++ b/src/internal/OpenApiTools/components/Parameter.ts
@@ -108,7 +108,15 @@ export const generatePropertySignatures = (
   converterContext: ConverterContext.Types,
 ): ts.PropertySignature[] => {
   const typeElementMap = parameters.reduce<Record<string, ts.PropertySignature>>((all, parameter) => {
-    const { name, typeElement } = generatePropertySignatureObject(entryPoint, currentPoint, store, factory, parameter, context, converterContext);
+    const { name, typeElement } = generatePropertySignatureObject(
+      entryPoint,
+      currentPoint,
+      store,
+      factory,
+      parameter,
+      context,
+      converterContext,
+    );
     return { ...all, [name]: typeElement };
   }, {});
   return Object.values(typeElementMap);

--- a/src/internal/OpenApiTools/components/Parameter.ts
+++ b/src/internal/OpenApiTools/components/Parameter.ts
@@ -50,10 +50,11 @@ export const generatePropertySignatureObject = (
     if (reference.type === "local") {
       context.setReferenceHandler(currentPoint, reference);
       const localRef = store.getParameter(reference.path);
+      const isPathProperty = localRef.in === "path";
       const name = converterContext.escapePropertySignatureName(localRef.name);
       const typeElement = factory.PropertySignature.create({
         name: name,
-        optional: false,
+        optional: isPathProperty ? false : !localRef.required,
         comment: localRef.description,
         type: factory.TypeReferenceNode.create({
           name: context.resolveReferencePath(currentPoint, reference.path).name,


### PR DESCRIPTION
## Summary

This PR solves the problem that required field for Parameter(LocalReference) is not enabled(always `optional: false`).

## Test Plan

The following yaml is processed correctly.

```yaml
openapi: 3.0.0
info:
  version: 0.0.1
paths:
  /test:
    get:
      operationId: Test
      parameters:
        - $ref: '#/components/parameters/Requied'
        - $ref: '#/components/parameters/Optional'
components:
  parameters:
    Requied:
      in: query
      name: requied
      description: required parameter
      required: true
      schema:
        type: integer
        format: int32
        example: 1
    Optional:
      in: query
      name: optional
      description: optional parameter
      required: false
      schema:
        type: integer
        format: int32
        example: 2
```
