### PR TITLE
fix: Trim the trailing slash of baesUrl

### DIFF
--- a/src/code-templates/api-client/ApiClientClass/MethodBody/PathParameter.ts
+++ b/src/code-templates/api-client/ApiClientClass/MethodBody/PathParameter.ts
@@ -21,9 +21,15 @@ const generateUrlVariableStatement = (
         factory.VariableDeclaration.create({
           name: "url",
           initializer: factory.BinaryExpression.create({
-            left: factory.PropertyAccessExpression.create({
-              name: "baseUrl",
-              expression: "this",
+            left: factory.CallExpression.create({
+              expression: factory.PropertyAccessExpression.create({
+                expression: factory.PropertyAccessExpression.create({
+                  name: "baseUrl",
+                  expression: "this",
+                }),
+                name: "replace",
+              }),
+              argumentsArray: [factory.RegularExpressionLiteral.create({ text: "/\\\/$/" }), factory.StringLiteral.create({ text: "" })],
             }),
             operator: "+",
             right: Utils.generateTemplateExpression(factory, urlTemplate),

--- a/src/internal/TsGenerator/factory/RegularExpressionLiteral.ts
+++ b/src/internal/TsGenerator/factory/RegularExpressionLiteral.ts
@@ -1,0 +1,21 @@
+import ts from "typescript";
+
+export interface Params$Create {
+  text: string;
+}
+
+export interface Factory {
+  create: (params: Params$Create) => ts.RegularExpressionLiteral;
+}
+
+export const create = ({ factory }: Pick<ts.TransformationContext, "factory">): Factory["create"] => (
+  params: Params$Create,
+): ts.RegularExpressionLiteral => {
+  return factory.createRegularExpressionLiteral(params.text);
+};
+
+export const make = (context: Pick<ts.TransformationContext, "factory">): Factory => {
+  return {
+    create: create(context),
+  };
+};

--- a/src/internal/TsGenerator/factory/index.ts
+++ b/src/internal/TsGenerator/factory/index.ts
@@ -21,6 +21,7 @@ import * as ParameterDeclaration from "./ParameterDeclaration";
 import * as PropertyAccessExpression from "./PropertyAccessExpression";
 import * as PropertyAssignment from "./PropertyAssignment";
 import * as PropertySignature from "./PropertySignature";
+import * as RegularExpressionLiteral from "./RegularExpressionLiteral";
 import * as ReturnStatement from "./ReturnStatement";
 import * as StringLiteral from "./StringLiteral";
 import * as TemplateExpression from "./TemplateExpression";
@@ -49,6 +50,7 @@ export interface Type {
   TypeOperatorNode: TypeOperatorNode.Factory;
   Namespace: Namespace.Factory;
   PropertySignature: PropertySignature.Factory;
+  RegularExpressionLiteral: RegularExpressionLiteral.Factory;
   TypeAliasDeclaration: TypeAliasDeclaration.Factory;
   TypeNode: TypeNode.Factory;
   LiteralTypeNode: LiteralTypeNode.Factory;
@@ -109,6 +111,7 @@ export const create = (): Type => {
     VariableStatement: VariableStatement.make(context),
     BinaryExpression: BinaryExpression.make(context),
     PropertyAccessExpression: PropertyAccessExpression.make(context),
+    RegularExpressionLiteral: RegularExpressionLiteral.make(context),
     NoSubstitutionTemplateLiteral: NoSubstitutionTemplateLiteral.make(context),
     TemplateSpan: TemplateSpan.make(context),
     TemplateExpression: TemplateExpression.make(context),

--- a/test/__tests__/__snapshots__/spit-code-test.ts.snap
+++ b/test/__tests__/__snapshots__/spit-code-test.ts.snap
@@ -111,7 +111,7 @@ export class Client<RequestOption> {
      * Request URI: /get/IncludeLocalReference
      */
     public async getIncludeLocalReference(params: Params$getIncludeLocalReference, option?: RequestOption): Promise<Response$getIncludeLocalReference$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/IncludeLocalReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeLocalReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -125,7 +125,7 @@ export class Client<RequestOption> {
      * Request URI: /get/IncludeRemoteReference
      */
     public async getIncludeRemoteReference(params: Params$getIncludeRemoteReference, option?: RequestOption): Promise<void> {
-        const url = this.baseUrl + \`/get/IncludeRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeRemoteReference\`;
         const headers = {
             \\"Content-Type\\": \\"application/json\\"
         };
@@ -139,7 +139,7 @@ export class Client<RequestOption> {
      * Request URI: /FullRemoteReference
      */
     public async getFullRemoteReference(params: Params$getFullRemoteReference, option?: RequestOption): Promise<Response$getFullRemoteReference$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/FullRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/FullRemoteReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -153,7 +153,7 @@ export class Client<RequestOption> {
      * Request URI: /get/reference/items
      */
     public async getReferenceItems(option?: RequestOption): Promise<Response$getReferenceItems$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/reference/items\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/reference/items\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -164,7 +164,7 @@ export class Client<RequestOption> {
      * Request URI: /get/books/{id}
      */
     public async getBookById(params: Params$getBookById, option?: RequestOption): Promise<Response$getBookById$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -175,7 +175,7 @@ export class Client<RequestOption> {
      * Request URI: /get/books/{id}
      */
     public async deleteBook(params: Params$deleteBook, option?: RequestOption): Promise<Response$deleteBook$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };

--- a/test/__tests__/__snapshots__/template-only-test.ts.snap
+++ b/test/__tests__/__snapshots__/template-only-test.ts.snap
@@ -59,7 +59,7 @@ export interface ApiClient<RequestOption> {
 export class Client<RequestOption> {
     constructor(private apiClient: ApiClient<RequestOption>, private baseUrl: string) { }
     public async getIncludeLocalReference(params: Params$getIncludeLocalReference, option?: RequestOption): Promise<Response$getIncludeLocalReference$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/IncludeLocalReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeLocalReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -69,7 +69,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public async getIncludeRemoteReference(params: Params$getIncludeRemoteReference, option?: RequestOption): Promise<void> {
-        const url = this.baseUrl + \`/get/IncludeRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeRemoteReference\`;
         const headers = {
             \\"Content-Type\\": \\"application/json\\"
         };
@@ -79,7 +79,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, params.requestBody, queryParameters, option);
     }
     public async getFullRemoteReference(params: Params$getFullRemoteReference, option?: RequestOption): Promise<Response$getFullRemoteReference$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/FullRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/FullRemoteReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -89,21 +89,21 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public async getReferenceItems(option?: RequestOption): Promise<Response$getReferenceItems$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/reference/items\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/reference/items\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public async getBookById(params: Params$getBookById, option?: RequestOption): Promise<Response$getBookById$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public async deleteBook(params: Params$deleteBook, option?: RequestOption): Promise<Response$deleteBook$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -172,7 +172,7 @@ export interface ApiClient<RequestOption> {
 export class Client<RequestOption> {
     constructor(private apiClient: ApiClient<RequestOption>, private baseUrl: string) { }
     public getIncludeLocalReference(params: Params$getIncludeLocalReference, option?: RequestOption): Response$getIncludeLocalReference$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/IncludeLocalReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeLocalReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -182,7 +182,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public getIncludeRemoteReference(params: Params$getIncludeRemoteReference, option?: RequestOption): void {
-        const url = this.baseUrl + \`/get/IncludeRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeRemoteReference\`;
         const headers = {
             \\"Content-Type\\": \\"application/json\\"
         };
@@ -192,7 +192,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, params.requestBody, queryParameters, option);
     }
     public getFullRemoteReference(params: Params$getFullRemoteReference, option?: RequestOption): Response$getFullRemoteReference$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/FullRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/FullRemoteReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -202,21 +202,21 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public getReferenceItems(option?: RequestOption): Response$getReferenceItems$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/reference/items\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/reference/items\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public getBookById(params: Params$getBookById, option?: RequestOption): Response$getBookById$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public deleteBook(params: Params$deleteBook, option?: RequestOption): Response$deleteBook$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };

--- a/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
@@ -383,7 +383,7 @@ export interface ApiClient<RequestOption> {
 export class Client<RequestOption> {
     constructor(private apiClient: ApiClient<RequestOption>, private baseUrl: string) { }
     public async getIncludeLocalReference(params: Params$getIncludeLocalReference, option?: RequestOption): Promise<Response$getIncludeLocalReference$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/IncludeLocalReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeLocalReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -393,7 +393,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public async getIncludeRemoteReference(params: Params$getIncludeRemoteReference, option?: RequestOption): Promise<void> {
-        const url = this.baseUrl + \`/get/IncludeRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeRemoteReference\`;
         const headers = {
             \\"Content-Type\\": \\"application/json\\"
         };
@@ -403,7 +403,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, params.requestBody, queryParameters, option);
     }
     public async getFullRemoteReference(params: Params$getFullRemoteReference, option?: RequestOption): Promise<Response$getFullRemoteReference$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/FullRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/FullRemoteReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -413,21 +413,21 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public async getReferenceItems(option?: RequestOption): Promise<Response$getReferenceItems$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/reference/items\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/reference/items\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public async getBookById(params: Params$getBookById, option?: RequestOption): Promise<Response$getBookById$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public async deleteBook(params: Params$deleteBook, option?: RequestOption): Promise<Response$deleteBook$Status$200[\\"application/json\\"]> {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -820,7 +820,7 @@ export interface ApiClient<RequestOption> {
 export class Client<RequestOption> {
     constructor(private apiClient: ApiClient<RequestOption>, private baseUrl: string) { }
     public getIncludeLocalReference(params: Params$getIncludeLocalReference, option?: RequestOption): Response$getIncludeLocalReference$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/IncludeLocalReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeLocalReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -830,7 +830,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public getIncludeRemoteReference(params: Params$getIncludeRemoteReference, option?: RequestOption): void {
-        const url = this.baseUrl + \`/get/IncludeRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/IncludeRemoteReference\`;
         const headers = {
             \\"Content-Type\\": \\"application/json\\"
         };
@@ -840,7 +840,7 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, params.requestBody, queryParameters, option);
     }
     public getFullRemoteReference(params: Params$getFullRemoteReference, option?: RequestOption): Response$getFullRemoteReference$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/FullRemoteReference\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/FullRemoteReference\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -850,21 +850,21 @@ export class Client<RequestOption> {
         return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public getReferenceItems(option?: RequestOption): Response$getReferenceItems$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/reference/items\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/reference/items\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public getBookById(params: Params$getBookById, option?: RequestOption): Response$getBookById$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
         return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
     }
     public deleteBook(params: Params$deleteBook, option?: RequestOption): Response$deleteBook$Status$200[\\"application/json\\"] {
-        const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
+        const url = this.baseUrl.replace(/\\\\/$/, \\"\\") + \`/get/books/\${params.parameter.id}\`;
         const headers = {
             Accept: \\"application/json\\"
         };


### PR DESCRIPTION
## Summary

Invalid code

```js
let baseUrl = "https://api.example.com/"

....
baseUrl + "/a/b/c";
# => https://api.example.com//a/b/c
```

Code that works reliably

```js
let baseUrl = "https://api.example.com/"

....
baseUrl.replace(/\/$/, "") + "/a/b/c";
# => https://api.example.com/a/b/c
```


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
