### PR TITLE
feat: support nullable field of combine schemas

### DIFF
--- a/src/internal/OpenApiTools/toTypeNode.ts
+++ b/src/internal/OpenApiTools/toTypeNode.ts
@@ -124,13 +124,13 @@ export const convert: Convert = (
   }
 
   if (Guard.isOneOfSchema(schema)) {
-    return generateMultiTypeNode(entryPoint, currentPoint, factory, schema.oneOf, context, convert, converterContext, "oneOf");
+    return nullable(factory, generateMultiTypeNode(entryPoint, currentPoint, factory, schema.oneOf, context, convert, converterContext, "oneOf"), !!schema.nullable);
   }
   if (Guard.isAllOfSchema(schema)) {
-    return generateMultiTypeNode(entryPoint, currentPoint, factory, schema.allOf, context, convert, converterContext, "allOf");
+    return nullable(factory, generateMultiTypeNode(entryPoint, currentPoint, factory, schema.allOf, context, convert, converterContext, "allOf"), !!schema.nullable);
   }
   if (Guard.isAnyOfSchema(schema)) {
-    return generateMultiTypeNode(entryPoint, currentPoint, factory, schema.anyOf, context, convert, converterContext, "anyOf");
+    return nullable(factory, generateMultiTypeNode(entryPoint, currentPoint, factory, schema.anyOf, context, convert, converterContext, "anyOf"), !!schema.nullable);
   }
 
   if (Guard.isHasNoMembersObject(schema)) {


### PR DESCRIPTION
## Summary

This PR solves the problem that nullable field for combine schemas(oneOf, anyOf, allOf) is not enabled.

## Test Plan

The following yaml is processed correctly.

```yaml
openapi: 3.0.0
info:
  version: 1.0.0
paths:
  /test:
    post:
      operationId: Test
      requestBody:
        content:
          application/json:
            schema:
              allOf:
                - $ref: '#/components/schemas/SchemaA'
                - $ref: '#/components/schemas/SchemaB'
              nullable: true
      responses:
        '200':
          content:
            application/json:
              schema:
                type: string
components:
  schemas:
    SchemaA:
      type: object
      required:
        - a
      properties:
        a:
          type: integer
          format: int32
    SchemaB:
      type: object
      required:
        - b
      properties:
        b:
          type: string
```
