### PR TITLE
fix: Fixed a bug where properties with '.' as a key were not referenced

### DIFF
--- a/src/internal/OpenApiTools/components/PathItem.ts
+++ b/src/internal/OpenApiTools/components/PathItem.ts
@@ -284,6 +284,7 @@ export const generateStatements = (
       ),
     );
   }
+  // TODO Check usage
   // if (pathItem.parameters) {
   //   Parameters.generateNamespaceWithList(entryPoint, currentPoint, store, factory, pathItem.parameters, context);
   // }

--- a/src/internal/ResolveReference/index.ts
+++ b/src/internal/ResolveReference/index.ts
@@ -9,6 +9,8 @@ export { OpenApi };
 
 export type ObjectLike = { [key: string]: any };
 
+const escapeFromJsonCyclic = (obj: any) => JSON.parse(JSON.stringify(obj));
+
 const isObject = (value: any): value is ObjectLike => {
   return !!value && value !== null && !Array.isArray(value) && typeof value === "object";
 };
@@ -89,7 +91,9 @@ const resolveLocalReference = (entryPoint: string, currentPoint: string, obj: an
           `This is an implementation error. Please report any reproducible information below.\nhttps://github.com/Himenon/openapi-typescript-code-generator/issues/new/choose\n`,
         );
       }
-      return DotProp.get(rootSchema, ref.path.replace(/\//g, "."));
+      // "." in the key
+      const escapedPath = ref.path.replace(/\./g, "\\.").replace(/\//g, ".");
+      return escapeFromJsonCyclic(DotProp.get(rootSchema, escapedPath));
     }
     return obj;
   }


### PR DESCRIPTION
## Summary

* Fixed a bug where properties with '.' as a key were not referenced

## Test Plan

```yaml
components:
  schemas:
    components:
      "v1.hoge":
          type: string
    requestBodies:
      sample:
        $ref: "#/components/schemas/v1.hoge"
```