### PR TITLE
fix(path-parameter): Support element access

### DIFF
--- a/src/code-templates/api-client/ApiClientClass/MethodBody/PathParameter.ts
+++ b/src/code-templates/api-client/ApiClientClass/MethodBody/PathParameter.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import type { TsGenerator } from "../../../../api";
 import type { CodeGenerator } from "../../../../types";
 import * as Utils from "../../utils";
+import { escapeText2 as escapeText } from "../../../../utils";
 
 export const isPathParameter = (params: any): params is CodeGenerator.PickedParameter => {
   return params.in === "path";
@@ -45,11 +46,14 @@ export const generateUrlTemplateExpression = (
   }, {});
   const urlTemplate: Utils.Params$TemplateExpression = [];
   let temporaryStringList: string[] = [];
+  // TODO generateVariableIdentifierに噛み合わ下げいいように変換する
   const replaceText = (text: string): string | undefined => {
     let replacedText = text;
-    Object.keys(patternMap).forEach(key => {
-      if (new RegExp(key).test(replacedText)) {
-        replacedText = replacedText.replace(new RegExp(key, "g"), `params.parameter.${patternMap[key]}`);
+    Object.keys(patternMap).forEach(pathParameterName => {
+      if (new RegExp(pathParameterName).test(replacedText)) {
+        const { text, escaped } = escapeText(patternMap[pathParameterName]);
+        const variableDeclaraText = escaped ? `params.parameter[${text}]` : `params.parameter.${text}`;
+        replacedText = replacedText.replace(new RegExp(pathParameterName, "g"), variableDeclaraText);
       }
     });
     return replacedText === text ? undefined : replacedText;

--- a/src/code-templates/api-client/__tests__/utils.test.ts
+++ b/src/code-templates/api-client/__tests__/utils.test.ts
@@ -1,0 +1,86 @@
+import * as Utils from "../utils";
+
+type OK = Utils.VariableElement;
+
+describe("Utils", () => {
+  test("splitVariableText", () => {
+    const splitVariableText = Utils.splitVariableText;
+    expect(splitVariableText("")).toStrictEqual<OK[]>([]);
+    expect(splitVariableText("a")).toStrictEqual<OK[]>([
+      {
+        kind: "string",
+        value: "a",
+      },
+    ]);
+    expect(splitVariableText("a.b")).toStrictEqual<OK[]>([
+      {
+        kind: "string",
+        value: "a",
+      },
+      {
+        kind: "string",
+        value: "b",
+      },
+    ]);
+    expect(splitVariableText("a.b.c")).toStrictEqual<OK[]>([
+      {
+        kind: "string",
+        value: "a",
+      },
+      {
+        kind: "string",
+        value: "b",
+      },
+
+      {
+        kind: "string",
+        value: "c",
+      },
+    ]);
+    expect(splitVariableText('a.b["c"]')).toStrictEqual<OK[]>([
+      {
+        kind: "string",
+        value: "a",
+      },
+      {
+        kind: "string",
+        value: "b",
+      },
+
+      {
+        kind: "element-access",
+        value: "c",
+      },
+    ]);
+    expect(splitVariableText('a.b["c.d"]')).toStrictEqual<OK[]>([
+      {
+        kind: "string",
+        value: "a",
+      },
+      {
+        kind: "string",
+        value: "b",
+      },
+
+      {
+        kind: "element-access",
+        value: "c.d",
+      },
+    ]);
+    expect(splitVariableText('a.b["c.d.e"]')).toStrictEqual<OK[]>([
+      {
+        kind: "string",
+        value: "a",
+      },
+      {
+        kind: "string",
+        value: "b",
+      },
+
+      {
+        kind: "element-access",
+        value: "c.d.e",
+      },
+    ]);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,3 +15,17 @@ export const escapeText = (text: string): string => {
   }
   return `"${text}"`;
 };
+
+/** TODO escapeTextにマージする */
+export const escapeText2 = (text: string): { escaped: boolean; text: string } => {
+  if (isAvailableVariableName(text)) {
+    return {
+      escaped: false,
+      text: text,
+    };
+  }
+  return {
+    escaped: true,
+    text: `"${text}"`,
+  };
+};

--- a/test/__tests__/__snapshots__/parameter-test.ts.snap
+++ b/test/__tests__/__snapshots__/parameter-test.ts.snap
@@ -316,6 +316,78 @@ exports[`Parameter api.test.domain 1`] = `
     }
   },
   {
+    \\"operationId\\": \\"searchBook\\",
+    \\"convertedParams\\": {
+      \\"escapedOperationId\\": \\"searchBook\\",
+      \\"argumentParamsTypeDeclaration\\": \\"Params$searchBook\\",
+      \\"functionName\\": \\"searchBook\\",
+      \\"requestContentTypeName\\": \\"RequestContentType$searchBook\\",
+      \\"responseContentTypeName\\": \\"ResponseContentType$searchBook\\",
+      \\"parameterName\\": \\"Parameter$searchBook\\",
+      \\"requestBodyName\\": \\"RequestBody$searchBook\\",
+      \\"hasRequestBody\\": false,
+      \\"hasParameter\\": true,
+      \\"pickedParameters\\": [
+        {
+          \\"name\\": \\"book.name\\",
+          \\"in\\": \\"path\\",
+          \\"required\\": true
+        }
+      ],
+      \\"requestContentTypes\\": [],
+      \\"responseSuccessNames\\": [
+        \\"Response$searchBook$Status$200\\"
+      ],
+      \\"responseFirstSuccessName\\": \\"Response$searchBook$Status$200\\",
+      \\"has2OrMoreSuccessNames\\": false,
+      \\"responseErrorNames\\": [],
+      \\"has2OrMoreRequestContentTypes\\": false,
+      \\"successResponseContentTypes\\": [
+        \\"application/json\\"
+      ],
+      \\"successResponseFirstContentType\\": \\"application/json\\",
+      \\"has2OrMoreSuccessResponseContentTypes\\": false,
+      \\"hasAdditionalHeaders\\": false,
+      \\"hasQueryParameters\\": false
+    },
+    \\"operationParams\\": {
+      \\"httpMethod\\": \\"get\\",
+      \\"requestUri\\": \\"/get/search/{book.name}\\",
+      \\"comment\\": \\"\\",
+      \\"deprecated\\": false,
+      \\"parameters\\": [
+        {
+          \\"in\\": \\"path\\",
+          \\"name\\": \\"book.name\\",
+          \\"required\\": true,
+          \\"schema\\": {
+            \\"type\\": \\"string\\"
+          }
+        }
+      ],
+      \\"responses\\": {
+        \\"200\\": {
+          \\"description\\": \\"Search Book Result\\",
+          \\"content\\": {
+            \\"application/json\\": {
+              \\"schema\\": {
+                \\"type\\": \\"object\\",
+                \\"properties\\": {
+                  \\"id\\": {
+                    \\"type\\": \\"number\\"
+                  },
+                  \\"bookTitle\\": {
+                    \\"type\\": \\"string\\"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
     \\"operationId\\": \\"getBookById\\",
     \\"convertedParams\\": {
       \\"escapedOperationId\\": \\"getBookById\\",

--- a/test/__tests__/__snapshots__/spit-code-test.ts.snap
+++ b/test/__tests__/__snapshots__/spit-code-test.ts.snap
@@ -42,6 +42,15 @@ export interface Response$getReferenceItems$Status$200 {
         books?: Schemas.Item[];
     };
 }
+export interface Parameter$searchBook {
+    \\"book.name\\": string;
+}
+export interface Response$searchBook$Status$200 {
+    \\"application/json\\": {
+        id?: number;
+        bookTitle?: string;
+    };
+}
 export interface Parameter$getBookById {
     /** Book ID */
     id: string;
@@ -72,6 +81,10 @@ export interface Params$getFullRemoteReference {
     parameter: Parameter$getFullRemoteReference;
 }
 export type ResponseContentType$getReferenceItems = keyof Response$getReferenceItems$Status$200;
+export type ResponseContentType$searchBook = keyof Response$searchBook$Status$200;
+export interface Params$searchBook {
+    parameter: Parameter$searchBook;
+}
 export type ResponseContentType$getBookById = keyof Response$getBookById$Status$200;
 export interface Params$getBookById {
     parameter: Parameter$getBookById;
@@ -92,12 +105,13 @@ export interface QueryParameter {
 export interface QueryParameters {
     [key: string]: QueryParameter;
 }
-export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
+export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$searchBook$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
 export namespace ErrorResponse {
     export type getIncludeLocalReference = void;
     export type getIncludeRemoteReference = void;
     export type getFullRemoteReference = void;
     export type getReferenceItems = void;
+    export type searchBook = void;
     export type getBookById = void;
     export type deleteBook = void;
 }
@@ -155,6 +169,17 @@ export class Client<RequestOption> {
      */
     public async getReferenceItems(option?: RequestOption): Promise<Response$getReferenceItems$Status$200[\\"application/json\\"]> {
         const url = this.baseUrl + \`/get/reference/items\`;
+        const headers = {
+            Accept: \\"application/json\\"
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+    }
+    /**
+     * operationId: searchBook
+     * Request URI: /get/search/{book.name}
+     */
+    public async searchBook(params: Params$searchBook, option?: RequestOption): Promise<Response$searchBook$Status$200[\\"application/json\\"]> {
+        const url = this.baseUrl + \`/get/search/\${params.parameter[\\"book.name\\"]}\`;
         const headers = {
             Accept: \\"application/json\\"
         };

--- a/test/__tests__/__snapshots__/template-only-test.ts.snap
+++ b/test/__tests__/__snapshots__/template-only-test.ts.snap
@@ -24,6 +24,10 @@ export interface Params$getFullRemoteReference {
     parameter: Parameter$getFullRemoteReference;
 }
 export type ResponseContentType$getReferenceItems = keyof Response$getReferenceItems$Status$200;
+export type ResponseContentType$searchBook = keyof Response$searchBook$Status$200;
+export interface Params$searchBook {
+    parameter: Parameter$searchBook;
+}
 export type ResponseContentType$getBookById = keyof Response$getBookById$Status$200;
 export interface Params$getBookById {
     parameter: Parameter$getBookById;
@@ -44,12 +48,13 @@ export interface QueryParameter {
 export interface QueryParameters {
     [key: string]: QueryParameter;
 }
-export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
+export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$searchBook$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
 export namespace ErrorResponse {
     export type getIncludeLocalReference = void;
     export type getIncludeRemoteReference = void;
     export type getFullRemoteReference = void;
     export type getReferenceItems = void;
+    export type searchBook = void;
     export type getBookById = void;
     export type deleteBook = void;
 }
@@ -91,6 +96,13 @@ export class Client<RequestOption> {
     }
     public async getReferenceItems(option?: RequestOption): Promise<Response$getReferenceItems$Status$200[\\"application/json\\"]> {
         const url = this.baseUrl + \`/get/reference/items\`;
+        const headers = {
+            Accept: \\"application/json\\"
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+    }
+    public async searchBook(params: Params$searchBook, option?: RequestOption): Promise<Response$searchBook$Status$200[\\"application/json\\"]> {
+        const url = this.baseUrl + \`/get/search/\${params.parameter[\\"book.name\\"]}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -138,6 +150,10 @@ export interface Params$getFullRemoteReference {
     parameter: Parameter$getFullRemoteReference;
 }
 export type ResponseContentType$getReferenceItems = keyof Response$getReferenceItems$Status$200;
+export type ResponseContentType$searchBook = keyof Response$searchBook$Status$200;
+export interface Params$searchBook {
+    parameter: Parameter$searchBook;
+}
 export type ResponseContentType$getBookById = keyof Response$getBookById$Status$200;
 export interface Params$getBookById {
     parameter: Parameter$getBookById;
@@ -158,12 +174,13 @@ export interface QueryParameter {
 export interface QueryParameters {
     [key: string]: QueryParameter;
 }
-export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
+export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$searchBook$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
 export namespace ErrorResponse {
     export type getIncludeLocalReference = void;
     export type getIncludeRemoteReference = void;
     export type getFullRemoteReference = void;
     export type getReferenceItems = void;
+    export type searchBook = void;
     export type getBookById = void;
     export type deleteBook = void;
 }
@@ -205,6 +222,13 @@ export class Client<RequestOption> {
     }
     public getReferenceItems(option?: RequestOption): Response$getReferenceItems$Status$200[\\"application/json\\"] {
         const url = this.baseUrl + \`/get/reference/items\`;
+        const headers = {
+            Accept: \\"application/json\\"
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+    }
+    public searchBook(params: Params$searchBook, option?: RequestOption): Response$searchBook$Status$200[\\"application/json\\"] {
+        const url = this.baseUrl + \`/get/search/\${params.parameter[\\"book.name\\"]}\`;
         const headers = {
             Accept: \\"application/json\\"
         };

--- a/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
@@ -318,6 +318,15 @@ export interface Response$getReferenceItems$Status$200 {
         books?: Schemas.Item[];
     };
 }
+export interface Parameter$searchBook {
+    \\"book.name\\": string;
+}
+export interface Response$searchBook$Status$200 {
+    \\"application/json\\": {
+        id?: number;
+        bookTitle?: string;
+    };
+}
 export interface Parameter$getBookById {
     /** Book ID */
     id: string;
@@ -348,6 +357,10 @@ export interface Params$getFullRemoteReference {
     parameter: Parameter$getFullRemoteReference;
 }
 export type ResponseContentType$getReferenceItems = keyof Response$getReferenceItems$Status$200;
+export type ResponseContentType$searchBook = keyof Response$searchBook$Status$200;
+export interface Params$searchBook {
+    parameter: Parameter$searchBook;
+}
 export type ResponseContentType$getBookById = keyof Response$getBookById$Status$200;
 export interface Params$getBookById {
     parameter: Parameter$getBookById;
@@ -368,12 +381,13 @@ export interface QueryParameter {
 export interface QueryParameters {
     [key: string]: QueryParameter;
 }
-export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
+export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$searchBook$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
 export namespace ErrorResponse {
     export type getIncludeLocalReference = void;
     export type getIncludeRemoteReference = void;
     export type getFullRemoteReference = void;
     export type getReferenceItems = void;
+    export type searchBook = void;
     export type getBookById = void;
     export type deleteBook = void;
 }
@@ -415,6 +429,13 @@ export class Client<RequestOption> {
     }
     public async getReferenceItems(option?: RequestOption): Promise<Response$getReferenceItems$Status$200[\\"application/json\\"]> {
         const url = this.baseUrl + \`/get/reference/items\`;
+        const headers = {
+            Accept: \\"application/json\\"
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+    }
+    public async searchBook(params: Params$searchBook, option?: RequestOption): Promise<Response$searchBook$Status$200[\\"application/json\\"]> {
+        const url = this.baseUrl + \`/get/search/\${params.parameter[\\"book.name\\"]}\`;
         const headers = {
             Accept: \\"application/json\\"
         };
@@ -819,6 +840,15 @@ export interface Response$getReferenceItems$Status$200 {
         books?: Schemas.Item[];
     };
 }
+export interface Parameter$searchBook {
+    \\"book.name\\": string;
+}
+export interface Response$searchBook$Status$200 {
+    \\"application/json\\": {
+        id?: number;
+        bookTitle?: string;
+    };
+}
 export interface Parameter$getBookById {
     /** Book ID */
     id: string;
@@ -849,6 +879,10 @@ export interface Params$getFullRemoteReference {
     parameter: Parameter$getFullRemoteReference;
 }
 export type ResponseContentType$getReferenceItems = keyof Response$getReferenceItems$Status$200;
+export type ResponseContentType$searchBook = keyof Response$searchBook$Status$200;
+export interface Params$searchBook {
+    parameter: Parameter$searchBook;
+}
 export type ResponseContentType$getBookById = keyof Response$getBookById$Status$200;
 export interface Params$getBookById {
     parameter: Parameter$getBookById;
@@ -869,12 +903,13 @@ export interface QueryParameter {
 export interface QueryParameters {
     [key: string]: QueryParameter;
 }
-export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
+export type SuccessResponses = Response$getIncludeLocalReference$Status$200 | Response$getFullRemoteReference$Status$200 | Response$getReferenceItems$Status$200 | Response$searchBook$Status$200 | Response$getBookById$Status$200 | Response$deleteBook$Status$200;
 export namespace ErrorResponse {
     export type getIncludeLocalReference = void;
     export type getIncludeRemoteReference = void;
     export type getFullRemoteReference = void;
     export type getReferenceItems = void;
+    export type searchBook = void;
     export type getBookById = void;
     export type deleteBook = void;
 }
@@ -916,6 +951,13 @@ export class Client<RequestOption> {
     }
     public getReferenceItems(option?: RequestOption): Response$getReferenceItems$Status$200[\\"application/json\\"] {
         const url = this.baseUrl + \`/get/reference/items\`;
+        const headers = {
+            Accept: \\"application/json\\"
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+    }
+    public searchBook(params: Params$searchBook, option?: RequestOption): Response$searchBook$Status$200[\\"application/json\\"] {
+        const url = this.baseUrl + \`/get/search/\${params.parameter[\\"book.name\\"]}\`;
         const headers = {
             Accept: \\"application/json\\"
         };

--- a/test/api.test.domain/index.yml
+++ b/test/api.test.domain/index.yml
@@ -380,6 +380,27 @@ paths:
                     type: array
                     items:
                       $ref: "./components/schemas/Item.yml"
+  /get/search/{book.name}:
+    get:
+      operationId: searchBook
+      parameters:
+        - in: path
+          name: book.name
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Search Book Result
+          content:
+            application/json: 
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: number
+                  bookTitle:
+                    type: string
   /get/books/{id}:
     parameters:
       - name: id


### PR DESCRIPTION
## Summary

Support below schema.

```yml
  /get/search/{book.name}: // <--- book.name
    get:
      operationId: searchBook
      parameters:
        - in: path
          name: book.name
          required: true
          schema:
            type: string
      responses:
        200:
          description: Search Book Result
          content:
            application/json: 
              schema:
                type: object
                properties:
                  id:
                    type: number
                  bookTitle:
                    type: string
```

## Test Plan

* https://github.com/argoproj/argo-cd/blob/master/assets/swagger.json