### PR TITLE
fix(query-parameter): Support element access

### DIFF
--- a/src/code-templates/api-client/ApiClientClass/MethodBody/index.ts
+++ b/src/code-templates/api-client/ApiClientClass/MethodBody/index.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 
 import type { TsGenerator } from "../../../../api";
 import type { CodeGenerator } from "../../../../types";
+import { escapeText2 as escapeText } from "../../../../utils";
 import * as Utils from "../../utils";
 import * as CallRequest from "./CallRequest";
 import * as HeaderParameter from "./HeaderParameter";
@@ -61,9 +62,11 @@ export const create = (factory: TsGenerator.Factory.Type, params: CodeGenerator.
   if (convertedParams.hasQueryParameters) {
     const queryParameter = pickedParameters.filter(item => item.in === "query");
     const queryObject = Object.values(queryParameter).reduce<{ [key: string]: QueryParameter.Item }>((previous, current) => {
+      const { text, escaped } = escapeText(current.name);
+      const variableDeclaraText = escaped ? `params.parameter[${text}]` : `params.parameter.${text}`;
       return {
         ...previous,
-        [current.name]: { type: "variable", value: `params.parameter.${current.name}`, style: current.style, explode: !!current.explode },
+        [current.name]: { type: "variable", value: variableDeclaraText, style: current.style, explode: !!current.explode },
       };
     }, {});
     statements.push(QueryParameter.create(factory, { variableName: "queryParameters", object: queryObject }));

--- a/test/__tests__/__snapshots__/parameter-test.ts.snap
+++ b/test/__tests__/__snapshots__/parameter-test.ts.snap
@@ -332,6 +332,10 @@ exports[`Parameter api.test.domain 1`] = `
           \\"name\\": \\"book.name\\",
           \\"in\\": \\"path\\",
           \\"required\\": true
+        },
+        {
+          \\"name\\": \\"from.publishedAt\\",
+          \\"in\\": \\"query\\"
         }
       ],
       \\"requestContentTypes\\": [],
@@ -348,7 +352,7 @@ exports[`Parameter api.test.domain 1`] = `
       \\"successResponseFirstContentType\\": \\"application/json\\",
       \\"has2OrMoreSuccessResponseContentTypes\\": false,
       \\"hasAdditionalHeaders\\": false,
-      \\"hasQueryParameters\\": false
+      \\"hasQueryParameters\\": true
     },
     \\"operationParams\\": {
       \\"httpMethod\\": \\"get\\",
@@ -362,6 +366,14 @@ exports[`Parameter api.test.domain 1`] = `
           \\"required\\": true,
           \\"schema\\": {
             \\"type\\": \\"string\\"
+          }
+        },
+        {
+          \\"in\\": \\"query\\",
+          \\"name\\": \\"from.publishedAt\\",
+          \\"schema\\": {
+            \\"type\\": \\"integer\\",
+            \\"format\\": \\"int32\\"
           }
         }
       ],

--- a/test/__tests__/__snapshots__/spit-code-test.ts.snap
+++ b/test/__tests__/__snapshots__/spit-code-test.ts.snap
@@ -44,6 +44,7 @@ export interface Response$getReferenceItems$Status$200 {
 }
 export interface Parameter$searchBook {
     \\"book.name\\": string;
+    \\"from.publishedAt\\"?: number;
 }
 export interface Response$searchBook$Status$200 {
     \\"application/json\\": {
@@ -183,7 +184,10 @@ export class Client<RequestOption> {
         const headers = {
             Accept: \\"application/json\\"
         };
-        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+        const queryParameters: QueryParameters = {
+            \\"from.publishedAt\\": { value: params.parameter[\\"from.publishedAt\\"], explode: false }
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     /**
      * operationId: getBookById

--- a/test/__tests__/__snapshots__/template-only-test.ts.snap
+++ b/test/__tests__/__snapshots__/template-only-test.ts.snap
@@ -106,7 +106,10 @@ export class Client<RequestOption> {
         const headers = {
             Accept: \\"application/json\\"
         };
-        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+        const queryParameters: QueryParameters = {
+            \\"from.publishedAt\\": { value: params.parameter[\\"from.publishedAt\\"], explode: false }
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public async getBookById(params: Params$getBookById, option?: RequestOption): Promise<Response$getBookById$Status$200[\\"application/json\\"]> {
         const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
@@ -232,7 +235,10 @@ export class Client<RequestOption> {
         const headers = {
             Accept: \\"application/json\\"
         };
-        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+        const queryParameters: QueryParameters = {
+            \\"from.publishedAt\\": { value: params.parameter[\\"from.publishedAt\\"], explode: false }
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public getBookById(params: Params$getBookById, option?: RequestOption): Response$getBookById$Status$200[\\"application/json\\"] {
         const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;

--- a/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
@@ -320,6 +320,7 @@ export interface Response$getReferenceItems$Status$200 {
 }
 export interface Parameter$searchBook {
     \\"book.name\\": string;
+    \\"from.publishedAt\\"?: number;
 }
 export interface Response$searchBook$Status$200 {
     \\"application/json\\": {
@@ -439,7 +440,10 @@ export class Client<RequestOption> {
         const headers = {
             Accept: \\"application/json\\"
         };
-        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+        const queryParameters: QueryParameters = {
+            \\"from.publishedAt\\": { value: params.parameter[\\"from.publishedAt\\"], explode: false }
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public async getBookById(params: Params$getBookById, option?: RequestOption): Promise<Response$getBookById$Status$200[\\"application/json\\"]> {
         const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;
@@ -842,6 +846,7 @@ export interface Response$getReferenceItems$Status$200 {
 }
 export interface Parameter$searchBook {
     \\"book.name\\": string;
+    \\"from.publishedAt\\"?: number;
 }
 export interface Response$searchBook$Status$200 {
     \\"application/json\\": {
@@ -961,7 +966,10 @@ export class Client<RequestOption> {
         const headers = {
             Accept: \\"application/json\\"
         };
-        return this.apiClient.request(\\"GET\\", url, headers, undefined, undefined, option);
+        const queryParameters: QueryParameters = {
+            \\"from.publishedAt\\": { value: params.parameter[\\"from.publishedAt\\"], explode: false }
+        };
+        return this.apiClient.request(\\"GET\\", url, headers, undefined, queryParameters, option);
     }
     public getBookById(params: Params$getBookById, option?: RequestOption): Response$getBookById$Status$200[\\"application/json\\"] {
         const url = this.baseUrl + \`/get/books/\${params.parameter.id}\`;

--- a/test/api.test.domain/index.yml
+++ b/test/api.test.domain/index.yml
@@ -389,6 +389,11 @@ paths:
           required: true
           schema:
             type: string
+        - in: query
+          name: from.publishedAt
+          schema:
+            type: integer
+            format: int32
       responses:
         200:
           description: Search Book Result


### PR DESCRIPTION
## Summary

* related: #67 

## Test Plan

```yml
  /get/search/{book.name}:
    get:
      operationId: searchBook
      parameters:
        - in: path
          name: book.name
          required: true
          schema:
            type: string
        - in: query
          name: from.publishedAt // <--- here
          schema:
            type: integer
            format: int32
```