### PR TITLE
feat: Updated behaviour of AdditionalProperties when owning OptionalPropery

### DIFF
--- a/src/internal/OpenApiTools/toTypeNode.ts
+++ b/src/internal/OpenApiTools/toTypeNode.ts
@@ -280,7 +280,7 @@ export const convert: Convert = (
             type: schema.type,
             value: [additionalProperties],
           });
-          return factory.UnionTypeNode.create({
+          return factory.IntersectionTypeNode.create({
             typeNodes: [objectTypeNode, additionalObjectTypeNode],
           });
         }

--- a/src/internal/OpenApiTools/toTypeNode.ts
+++ b/src/internal/OpenApiTools/toTypeNode.ts
@@ -169,8 +169,8 @@ export const convert: Convert = (
       return nullable(factory, typeNode, schema.nullable);
     }
     if (option && option.parent) {
-      Logger.info("Parent Schema:");
-      Logger.info(JSON.stringify(option.parent));
+      const message = ["Schema Type is not found and is converted to the type any. The parent Schema is as follows.", "", JSON.stringify(option.parent), ""].join("\n");
+      Logger.info(message);
     }
     const typeNode = factory.TypeNode.create({
       type: "any",

--- a/src/internal/OpenApiTools/toTypeNode.ts
+++ b/src/internal/OpenApiTools/toTypeNode.ts
@@ -254,12 +254,7 @@ export const convert: Convert = (
         });
       }
 
-      let hasOptionalProperty = false;
       const value: ts.PropertySignature[] = Object.entries(schema.properties || {}).map(([name, jsonSchema]) => {
-        const isOptional = !required.includes(name);
-        if (!hasOptionalProperty && isOptional) {
-          hasOptionalProperty = true;
-        }
         return factory.PropertySignature.create({
           name: converterContext.escapePropertySignatureName(name),
           type: convert(entryPoint, currentPoint, factory, jsonSchema, context, converterContext, { parent: schema.properties }),
@@ -274,6 +269,8 @@ export const convert: Convert = (
             parent: schema.properties,
           }),
         });
+
+        const hasOptionalProperty = Object.keys(schema.properties || {}).some(key => !required.includes(key));
         if (hasOptionalProperty) {
           const objectTypeNode = factory.TypeNode.create({
             type: schema.type,

--- a/test/__tests__/__snapshots__/typedef-only-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-only-test.ts.snap
@@ -314,6 +314,11 @@ export namespace Schemas {
     }
     export type InferStringEnum = \\"a\\" | \\"b\\" | \\"c\\";
     export type InferAnyNullable = null;
+    export interface OptionalPropertiesAndAdditionalProperties {
+        key?: string;
+        description?: string;
+        [key: string]: string;
+    }
 }
 "
 `;

--- a/test/__tests__/__snapshots__/typedef-only-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-only-test.ts.snap
@@ -318,7 +318,7 @@ export namespace Schemas {
         body?: {
             key?: string;
             description?: string;
-        } | {
+        } & {
             [key: string]: string;
         };
     }

--- a/test/__tests__/__snapshots__/typedef-only-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-only-test.ts.snap
@@ -315,9 +315,12 @@ export namespace Schemas {
     export type InferStringEnum = \\"a\\" | \\"b\\" | \\"c\\";
     export type InferAnyNullable = null;
     export interface OptionalPropertiesAndAdditionalProperties {
-        key?: string;
-        description?: string;
-        [key: string]: string;
+        body?: {
+            key?: string;
+            description?: string;
+        } | {
+            [key: string]: string;
+        };
     }
 }
 "

--- a/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
@@ -1045,7 +1045,7 @@ export namespace Schemas {
         body?: {
             key?: string;
             description?: string;
-        } | {
+        } & {
             [key: string]: string;
         };
     }

--- a/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
@@ -1041,6 +1041,11 @@ export namespace Schemas {
     }
     export type InferStringEnum = \\"a\\" | \\"b\\" | \\"c\\";
     export type InferAnyNullable = null;
+    export interface OptionalPropertiesAndAdditionalProperties {
+        key?: string;
+        description?: string;
+        [key: string]: string;
+    }
 }
 export type HttpMethod = \\"GET\\" | \\"PUT\\" | \\"POST\\" | \\"DELETE\\" | \\"OPTIONS\\" | \\"HEAD\\" | \\"PATCH\\" | \\"TRACE\\";
 export interface ObjectLike {

--- a/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/__snapshots__/typedef-with-template-test.ts.snap
@@ -1042,9 +1042,12 @@ export namespace Schemas {
     export type InferStringEnum = \\"a\\" | \\"b\\" | \\"c\\";
     export type InferAnyNullable = null;
     export interface OptionalPropertiesAndAdditionalProperties {
-        key?: string;
-        description?: string;
-        [key: string]: string;
+        body?: {
+            key?: string;
+            description?: string;
+        } | {
+            [key: string]: string;
+        };
     }
 }
 export type HttpMethod = \\"GET\\" | \\"PUT\\" | \\"POST\\" | \\"DELETE\\" | \\"OPTIONS\\" | \\"HEAD\\" | \\"PATCH\\" | \\"TRACE\\";

--- a/test/infer.domain/index.yml
+++ b/test/infer.domain/index.yml
@@ -37,3 +37,12 @@ components:
       enum: [a, b, c]
     InferAnyNullable:
       nullable: true
+    OptionalPropertiesAndAdditionalProperties:
+      type: object
+      properties:
+        key:
+          type: string
+        description:
+          type: string
+      additionalProperties:
+        type: string

--- a/test/infer.domain/index.yml
+++ b/test/infer.domain/index.yml
@@ -40,9 +40,12 @@ components:
     OptionalPropertiesAndAdditionalProperties:
       type: object
       properties:
-        key:
-          type: string
-        description:
-          type: string
-      additionalProperties:
-        type: string
+        body:
+          type: object
+          properties:
+            key:
+              type: string
+            description:
+              type: string
+          additionalProperties:
+            type: string


### PR DESCRIPTION
## Summary

GitHub OpenAPI Schemas has below

```yml
schemas:
  integration:
    type: object
    properties:
        permissions:
          description: The set of permissions for the GitHub app
          type: object
          properties:
            issues:
              type: string
            checks:
              type: string
            metadata:
              type: string
            contents:
              type: string
            deployments:
              type: string
          additionalProperties:
            type: string
          example:
            issues: read
            deployments: write
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
