### PR TITLE
fix: export type Client for FunctionalApiClient

### DIFF
--- a/src/code-templates/functional-api-client/FunctionalApiClient/ClientTypeDefinition.ts
+++ b/src/code-templates/functional-api-client/FunctionalApiClient/ClientTypeDefinition.ts
@@ -1,11 +1,20 @@
+import ts from "typescript";
 import type { TsGenerator } from "../../../api";
 
-export const create = (factory: TsGenerator.Factory.Type) => {
-  return factory.TypeAliasDeclaration.create({
-    export: true,
-    name: "Client",
-    type: factory.TypeReferenceNode.create({
-      name: `ReturnType<typeof createClient>`,
+export const create = (factory: TsGenerator.Factory.Type): ts.TypeAliasDeclaration[] => {
+  return [
+    factory.TypeAliasDeclaration.create({
+      name: "ClientFunction<RequestOption>",
+      type: factory.TypeReferenceNode.create({
+        name: `typeof createClient<RequestOption>`,
+      })
+    }),
+    factory.TypeAliasDeclaration.create({
+      export: true,
+      name: "Client<RequestOption>",
+      type: factory.TypeReferenceNode.create({
+        name: `ReturnType<ClientFunction<RequestOption>>`,
+      })
     })
-  })
+  ]
 };

--- a/src/code-templates/functional-api-client/index.ts
+++ b/src/code-templates/functional-api-client/index.ts
@@ -37,6 +37,9 @@ export const generator: CodeGenerator.GenerateFunction<Option> = (
 
   const apiClientStatement = FunctionalApiClient.create(factory, codeGeneratorParamsList, option || {});
   statements.push(apiClientStatement);
-  statements.push(ClientTypeDefinition.create(factory));
+  ClientTypeDefinition.create(factory).forEach(statement => {
+    statements.push(statement);
+  })
+  
   return statements;
 };

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,2 +1,2 @@
 export const Name = "@himenon/openapi-typescript-code-generator";
-export const Version = "0.22.0";
+export const Version = "0.22.1";

--- a/test/__tests__/functional/__snapshots__/argo-rollout-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/argo-rollout-test.ts.snap
@@ -3924,6 +3924,6 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/argo-rollout-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/argo-rollout-test.ts.snap
@@ -3923,6 +3923,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/format.domain.ts.snap
+++ b/test/__tests__/functional/__snapshots__/format.domain.ts.snap
@@ -49,6 +49,7 @@ export interface ApiClient<RequestOption> {
 export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>, baseUrl: string) => {
     return {};
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/format.domain.ts.snap
+++ b/test/__tests__/functional/__snapshots__/format.domain.ts.snap
@@ -50,6 +50,6 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     return {};
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/multi-type.test.domain.ts.snap
+++ b/test/__tests__/functional/__snapshots__/multi-type.test.domain.ts.snap
@@ -72,7 +72,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 

--- a/test/__tests__/functional/__snapshots__/multi-type.test.domain.ts.snap
+++ b/test/__tests__/functional/__snapshots__/multi-type.test.domain.ts.snap
@@ -71,7 +71,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 

--- a/test/__tests__/functional/__snapshots__/spit-code-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/spit-code-test.ts.snap
@@ -230,7 +230,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 

--- a/test/__tests__/functional/__snapshots__/spit-code-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/spit-code-test.ts.snap
@@ -231,7 +231,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 

--- a/test/__tests__/functional/__snapshots__/template-only-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/template-only-test.ts.snap
@@ -136,7 +136,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -276,7 +276,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -311,6 +311,6 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     return {};
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/template-only-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/template-only-test.ts.snap
@@ -135,7 +135,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -274,7 +275,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -308,6 +310,7 @@ export interface ApiClient<RequestOption> {
 export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>, baseUrl: string) => {
     return {};
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/typedef-with-template-test.ts.snap
@@ -484,7 +484,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -548,7 +549,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1036,7 +1038,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1093,7 +1096,8 @@ export interface ApiClient<RequestOption> {
 export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>, baseUrl: string) => {
     return {};
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1231,7 +1235,8 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1377,6 +1382,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/typedef-with-template-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/typedef-with-template-test.ts.snap
@@ -485,7 +485,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -550,7 +550,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1039,7 +1039,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1097,7 +1097,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     return {};
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1236,7 +1236,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;
 
@@ -1383,6 +1383,6 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/unknown-schema-domain-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/unknown-schema-domain-test.ts.snap
@@ -56,6 +56,6 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
     };
 };
 type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
-export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
+export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
 "
 `;

--- a/test/__tests__/functional/__snapshots__/unknown-schema-domain-test.ts.snap
+++ b/test/__tests__/functional/__snapshots__/unknown-schema-domain-test.ts.snap
@@ -55,6 +55,7 @@ export const createClient = <RequestOption>(apiClient: ApiClient<RequestOption>,
         }
     };
 };
-export type Client = ReturnType<typeof createClient>;
+type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
+export type Client<RequestOption> = ReturnType<<ClientFunction<RequestOption>>;
 "
 `;


### PR DESCRIPTION
## Summary

```ts
type ClientFunction<RequestOption> = typeof createClient<RequestOption>;
export type Client<RequestOption> = ReturnType<ClientFunction<RequestOption>>;
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
