### PR TITLE
fix(build): bundle pure esm package

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -61,7 +61,7 @@ module.exports = {
       },
       to: {
         dependencyTypes: ["npm-dev"],
-        pathNot: "typescript",
+        pathNot: ["typescript", "dot-prop", "@himenon/path-oriented-data-structure"],
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -93,16 +93,15 @@
     "node-fetch": "2.6.1"
   },
   "dependencies": {
-    "@himenon/path-oriented-data-structure": "1.0.2",
     "@types/json-schema": "7.0.15",
     "ajv": "8.12.0",
-    "dot-prop": "8.0.2",
     "js-yaml": "4.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.5.3",
     "@commitlint/cli": "18.6.0",
     "@commitlint/config-conventional": "18.6.0",
+    "@himenon/path-oriented-data-structure": "1.0.2",
     "@swc/core": "^1.3.107",
     "@swc/helpers": "^0.5.3",
     "@swc/jest": "^0.2.34",
@@ -116,6 +115,7 @@
     "cpy": "11.0.0",
     "cross-env": "^7.0.3",
     "dependency-cruiser": "16.1.0",
+    "dot-prop": "8.0.2",
     "execa": "8.0.1",
     "generate-changelog": "1.8.0",
     "import-sort-style-module": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,18 +9,12 @@ overrides:
   node-fetch: 2.6.1
 
 dependencies:
-  '@himenon/path-oriented-data-structure':
-    specifier: 1.0.2
-    version: 1.0.2
   '@types/json-schema':
     specifier: 7.0.15
     version: 7.0.15
   ajv:
     specifier: 8.12.0
     version: 8.12.0
-  dot-prop:
-    specifier: 8.0.2
-    version: 8.0.2
   js-yaml:
     specifier: 4.1.0
     version: 4.1.0
@@ -35,6 +29,9 @@ devDependencies:
   '@commitlint/config-conventional':
     specifier: 18.6.0
     version: 18.6.0
+  '@himenon/path-oriented-data-structure':
+    specifier: 1.0.2
+    version: 1.0.2
   '@swc/core':
     specifier: ^1.3.107
     version: 1.3.107(@swc/helpers@0.5.3)
@@ -74,6 +71,9 @@ devDependencies:
   dependency-cruiser:
     specifier: 16.1.0
     version: 16.1.0
+  dot-prop:
+    specifier: 8.0.2
+    version: 8.0.2
   execa:
     specifier: 8.0.1
     version: 8.0.1
@@ -961,7 +961,7 @@ packages:
   /@himenon/path-oriented-data-structure@1.0.2:
     resolution: {integrity: sha512-KMl4j9SI1obB0K9KhCpmVtVLNn7ecTScxeT9tLwpW+2fa6CO089RRm8KoW2Vl4Hqg4Dlc/j1KBHyCoSh3/kZVA==}
     engines: {node: '>=20', pnpm: '>=8'}
-    dev: false
+    dev: true
 
   /@hutson/parse-repository-url@3.0.2:
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
@@ -3391,7 +3391,7 @@ packages:
     engines: {node: '>=16'}
     dependencies:
       type-fest: 3.13.1
-    dev: false
+    dev: true
 
   /dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
@@ -7895,6 +7895,7 @@ packages:
   /type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
+    dev: true
 
   /type-fest@4.10.2:
     resolution: {integrity: sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==}


### PR DESCRIPTION
## Summary
When using the openapi-typescript-code-generator as CJS, the following error occurs.
```sh
❯ node --input-type=commonjs -e "require('./dist/index.cjs')"
/Users/kei_sakamoto/workspace/openapi-typescript-code-generator/dist/index.cjs:1377
var DotProp2 = __toESM(require("dot-prop"), 1);
                       ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/kei_sakamoto/workspace/openapi-typescript-code-generator/node_modules/.pnpm/dot-prop@8.0.2/node_modules/dot-prop/index.js from /Users/kei_sakamoto/workspace/openapi-typescript-code-generator/dist/index.cjs not supported.
Instead change the require of index.js in /Users/kei_sakamoto/workspace/openapi-typescript-code-generator/dist/index.cjs to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/kei_sakamoto/workspace/openapi-typescript-code-generator/dist/index.cjs:1377:24)
    at [eval]:1:1
    at Script.runInThisContext (node:vm:122:12)
    at Object.runInThisContext (node:vm:296:38)
    at [eval]-wrapper:6:24 {
  code: 'ERR_REQUIRE_ESM'
}
```

To resolve this issue, we need to bundle pure esm package.
However, tsup does not bundle packages that are listed in the dependencies.(see https://tsup.egoist.dev/#excluding-packages , https://github.com/egoist/tsup/issues/628#issuecomment-1159734075)
As a workaround, I moved the pure ESM package to devDependencies.
## Test Plan
verify that the package can be loaded in both ESM and CJS with the following command.
```sh
node --input-type=module -e "import {CodeGenerator} from './dist/index.js'"
node --input-type=commonjs -e "require('./dist/index.cjs')"
```