### PR TITLE
feat: support subpath exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ main();
 import * as fs from "fs";
 
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 const main = () => {
   const codeGenerator = new CodeGenerator("your/openapi/spec.yml");
@@ -79,7 +79,7 @@ main();
 This library provides three types of templates
 
 ```ts
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
 
 Templates.ClassApiClient.generator;
 Templates.FunctionalApiClient.generator;
@@ -273,8 +273,8 @@ export const createPublisherV2 =
 import * as fs from "fs";
 
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 const main = () => {
   const codeGenerator = new CodeGenerator("your/openapi/spec.yml");
@@ -310,7 +310,7 @@ The examples in this section can be used in the following ways
 import * as fs from "fs";
 
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 /** Write the definition of the Code Template here. */
 const customGenerator: Types.CodeGenerator.CustomGenerator<{}> = {
@@ -329,7 +329,7 @@ fs.writeFileSync("output/file/name", code, { encoding: "utf-8" });
 A self-defined code generator can return an array of `string`.
 
 ```ts
-import * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 interface Option {
   showLog?: boolean;
@@ -354,7 +354,7 @@ The self-defined code generator can accept parameters extracted from OpenAPI Sch
 See Type definitions for available parameters.
 
 ```ts
-import * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 interface Option {}
 
@@ -442,8 +442,8 @@ You can extend your code using the API for generating code.
 You can directly use the Template literals or use the wrapper API provided by this library.
 
 ```ts
-import * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
-import { TsGenerator } from "@himenon/openapi-typescript-code-generator/dist/api";
+import * as Types from "@himenon/openapi-typescript-code-generator/types";
+import { TsGenerator } from "@himenon/openapi-typescript-code-generator/api";
 
 interface Option {}
 
@@ -504,7 +504,7 @@ This is a type definition file for `Templates.FunctionalApiClient`. The reason i
 ### TsGenerator
 
 ```ts
-import { TsGenerator } from "@himenon/openapi-typescript-code-generator/dist/api";
+import { TsGenerator } from "@himenon/openapi-typescript-code-generator/api";
 ```
 
 This is an API for generating code using Template literals.
@@ -513,7 +513,7 @@ It is subject to change without notice.
 ### OpenApiTools
 
 ```ts
-import { OpenApiTools } from "@himenon/openapi-typescript-code-generator/dist/api";
+import { OpenApiTools } from "@himenon/openapi-typescript-code-generator/api";
 ```
 
 #### Parser

--- a/docs/ja/README-ja.md
+++ b/docs/ja/README-ja.md
@@ -46,8 +46,8 @@ main();
 import * as fs from "fs";
 
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 const main = () => {
   const codeGenerator = new CodeGenerator("your/openapi/spec.yml");
@@ -73,7 +73,7 @@ main();
 本ライブラリからは 3 種類提供しています。
 
 ```ts
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
 
 Templates.ClassApiClient.generator;
 Templates.FunctionalApiClient.generator;
@@ -269,8 +269,8 @@ export const createPublisherV2 =
 import * as fs from "fs";
 
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 const main = () => {
   const codeGenerator = new CodeGenerator("your/openapi/spec.yml");
@@ -306,7 +306,7 @@ main();
 import * as fs from "fs";
 
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 /** ここにCode Templateの定義を記述してください  */
 const customGenerator: Types.CodeGenerator.CustomGenerator<{}> = {
@@ -325,7 +325,7 @@ fs.writeFileSync("output/file/name", code, { encoding: "utf-8" });
 独自定義のコードジェネレーターは`string`の配列を返すことができます。
 
 ```ts
-import * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 interface Option {
   showLog?: boolean;
@@ -350,7 +350,7 @@ const customGenerator: Types.CodeGenerator.CustomGenerator<Option> = {
 利用可能なパラメーターは型定義を参照してください。
 
 ```ts
-import * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 interface Option {}
 
@@ -438,8 +438,8 @@ export namespace Schemas {
 直接テンプレートリテラルを利用したり、本ライブラリが提供するコード生成用 API を利用できます。
 
 ```ts
-import * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
-import { TsGenerator } from "@himenon/openapi-typescript-code-generator/dist/api";
+import * as Types from "@himenon/openapi-typescript-code-generator/types";
+import { TsGenerator } from "@himenon/openapi-typescript-code-generator/api";
 
 interface Option {}
 
@@ -500,7 +500,7 @@ OpenAPI Schema から抽出したパラメーターを取得できます。
 ### TsGenerator
 
 ```ts
-import { TsGenerator } from "@himenon/openapi-typescript-code-generator/dist/api";
+import { TsGenerator } from "@himenon/openapi-typescript-code-generator/api";
 ```
 
 内部で利用している、テンプレートリテラルを用いてコードを生成するための API です。
@@ -509,7 +509,7 @@ import { TsGenerator } from "@himenon/openapi-typescript-code-generator/dist/api
 ### OpenApiTools
 
 ```ts
-import { OpenApiTools } from "@himenon/openapi-typescript-code-generator/dist/api";
+import { OpenApiTools } from "@himenon/openapi-typescript-code-generator/api";
 ```
 
 #### Parser

--- a/examples/apis/codegen.ts
+++ b/examples/apis/codegen.ts
@@ -1,6 +1,6 @@
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 import * as fs from "fs";
 
 const main = () => {

--- a/examples/readme-sample/ast-code-template.ts
+++ b/examples/readme-sample/ast-code-template.ts
@@ -1,5 +1,5 @@
-import { TsGenerator } from "@himenon/openapi-typescript-code-generator/dist/api";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import { TsGenerator } from "@himenon/openapi-typescript-code-generator/api";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 type Option = {};
 

--- a/examples/readme-sample/generator-template.ts
+++ b/examples/readme-sample/generator-template.ts
@@ -1,5 +1,5 @@
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 import * as fs from "fs";
 
 /** ここにCode Templateの定義を記述してください  */

--- a/examples/readme-sample/split-typedef-and-api-client.ts
+++ b/examples/readme-sample/split-typedef-and-api-client.ts
@@ -1,6 +1,6 @@
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 import * as fs from "fs";
 
 const main = () => {

--- a/examples/readme-sample/text-base-code-template.ts
+++ b/examples/readme-sample/text-base-code-template.ts
@@ -1,4 +1,4 @@
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 interface Option {
   showLog?: boolean;

--- a/examples/readme-sample/typedef-and-api-client.ts
+++ b/examples/readme-sample/typedef-and-api-client.ts
@@ -1,6 +1,6 @@
 import { CodeGenerator } from "@himenon/openapi-typescript-code-generator";
-import * as Templates from "@himenon/openapi-typescript-code-generator/dist/templates";
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import * as Templates from "@himenon/openapi-typescript-code-generator/templates";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 import * as fs from "fs";
 
 const main = () => {

--- a/examples/readme-sample/use-extract-schema-params.ts
+++ b/examples/readme-sample/use-extract-schema-params.ts
@@ -1,4 +1,4 @@
-import type * as Types from "@himenon/openapi-typescript-code-generator/dist/types";
+import type * as Types from "@himenon/openapi-typescript-code-generator/types";
 
 type Option = {};
 

--- a/package.json
+++ b/package.json
@@ -27,22 +27,27 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./dist/api": {
+    "./api": {
+      "types": "./dist/api.d.ts",
       "import": "./dist/api.js",
       "require": "./dist/api.cjs"
     },
-    "./dist/templates": {
+    "./templates": {
+      "types": "./dist/templates.d.ts",
       "import": "./dist/templates.js",
       "require": "./dist/templates.cjs"
     },
-    "./dist/types": {
+    "./types": {
+      "types": "./dist/types.d.ts",
       "import": "./dist/types.js",
       "require": "./dist/types.cjs"
     },
-    "./dist/meta": {
+    "./meta": {
+      "types": "./dist/meta.d.ts",
       "import": "./dist/meta.js",
       "require": "./dist/meta.cjs"
     }


### PR DESCRIPTION
#### Summary
Implemented subpath exports to allow cleaner import paths without the `dist/` prefix.

**Changes:**
- Updated `package.json` with `exports` field for `./api`, `./templates`, `./types`, and `./meta`.
- Added `types` field to each export for better type resolution.
- Updated `README.md`, `docs/ja/README-ja.md`, and all files in `examples/` to use the new import paths.

#### BREAKING CHANGE
Import paths for sub-modules have been updated. Custom templates or scripts using the old paths will need to be updated.
- `@himenon/openapi-typescript-code-generator/dist/templates` -> `@himenon/openapi-typescript-code-generator/templates`
- `@himenon/openapi-typescript-code-generator/dist/types` -> `@himenon/openapi-typescript-code-generator/types`
- `@himenon/openapi-typescript-code-generator/dist/api` -> `@himenon/openapi-typescript-code-generator/api`
- `@himenon/openapi-typescript-code-generator/dist/meta` -> `@himenon/openapi-typescript-code-generator/meta`
