### PR TITLE
chore(workflow): switch npm release to OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
@@ -61,5 +62,3 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: NPM_CONFIG_PROVENANCE=true pnpm run release:npm:registry
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "openapi-generator",
     "typescript"
   ],
-  "homepage": "https://github.com/Himenon/openapi-typescript-code-generator#readme",
+  "homepage": "https://github.com/Himenon/openapi-typescript-code-generator",
   "bugs": {
     "url": "https://github.com/Himenon/openapi-typescript-code-generator/issues"
   },
@@ -66,8 +66,8 @@
     "format": "biome check --write --unsafe .",
     "lerna:version:up": "lerna version --yes",
     "lint": "biome check .",
-    "release:github:registry": "pnpm publish  --no-git-checks --registry https://npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}",
-    "release:npm:registry": "pnpm publish --no-git-checks",
+    "release:npm:registry": "pnpm publish --access public --no-git-checks",
+    "release:github:registry": "pnpm publish --access public --no-git-checks",
     "test": "run-p test:depcruise test:vitest test:code:gen:* test:snapshot",
     "test:code:gen": "run-p test:code:gen:*",
     "test:code:gen:class": "pnpm ts ./scripts/testCodeGenWithClass.ts",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@himenon/openapi-typescript-code-generator",
-<<<<<<< Updated upstream
   "version": "2.0.1",
-=======
-  "version": "2.0P.0",
->>>>>>> Stashed changes
   "description": "OpenAPI Code Generator using Template literals.",
   "keywords": [
     "openapi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@himenon/openapi-typescript-code-generator",
+<<<<<<< Updated upstream
   "version": "2.0.1",
+=======
+  "version": "2.0P.0",
+>>>>>>> Stashed changes
   "description": "OpenAPI Code Generator using Template literals.",
   "keywords": [
     "openapi",


### PR DESCRIPTION
## Summary

This PR migrates the npm release authentication from a static `NPM_TOKEN` (secret) to OpenID Connect (OIDC) via GitHub's Trusted Publishers.

## Changes
- Added `id-token: write` and `contents: read` permissions to the `release-npm-registry` job.
- Removed the dependency on `secrets.NPM_TOKEN`.
- Maintained `NPM_CONFIG_PROVENANCE=true` for secure package publishing.

## Impact
- **Security**: No longer requires managing long-lived npm tokens in GitHub Secrets.
- **Workflow**: Authentication is now handled automatically by GitHub's OIDC provider.
