### PR TITLE
chore: improve release workflow and bump node version to v24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
         os: [windows-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
@@ -61,5 +62,3 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: NPM_CONFIG_PROVENANCE=true pnpm run release:npm:registry
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: https://npm.pkg.github.com
           scope: "@Himenon"
           cache: "pnpm"
@@ -33,7 +33,7 @@ jobs:
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: https://npm.pkg.github.com
           scope: "@Himenon"
           cache: "pnpm"
@@ -56,7 +56,7 @@ jobs:
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
       - run: pnpm install

--- a/.github/workflows/versionUp.yml
+++ b/.github/workflows/versionUp.yml
@@ -10,13 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          ref: main
       - uses: ./.github/actions/initialize
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: "pnpm"
       - run: pnpm i --frozen-lockfile
       - name: Auto version update

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "openapi-generator",
     "typescript"
   ],
-  "homepage": "https://github.com/Himenon/openapi-typescript-code-generator#readme",
+  "homepage": "https://github.com/Himenon/openapi-typescript-code-generator",
   "bugs": {
     "url": "https://github.com/Himenon/openapi-typescript-code-generator/issues"
   },
@@ -66,8 +66,8 @@
     "format": "biome check --write --unsafe .",
     "lerna:version:up": "lerna version --yes",
     "lint": "biome check .",
-    "release:github:registry": "pnpm publish  --no-git-checks --registry https://npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}",
-    "release:npm:registry": "pnpm publish --no-git-checks",
+    "release:npm:registry": "pnpm publish --access public --no-git-checks",
+    "release:github:registry": "pnpm publish --access public --no-git-checks",
     "test": "run-p test:depcruise test:vitest test:code:gen:* test:snapshot",
     "test:code:gen": "run-p test:code:gen:*",
     "test:code:gen:class": "pnpm ts ./scripts/testCodeGenWithClass.ts",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@himenon/openapi-typescript-code-generator",
-<<<<<<< Updated upstream
   "version": "2.0.1",
-=======
-  "version": "2.0P.0",
->>>>>>> Stashed changes
   "description": "OpenAPI Code Generator using Template literals.",
   "keywords": [
     "openapi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@himenon/openapi-typescript-code-generator",
+<<<<<<< Updated upstream
   "version": "2.0.1",
+=======
+  "version": "2.0P.0",
+>>>>>>> Stashed changes
   "description": "OpenAPI Code Generator using Template literals.",
   "keywords": [
     "openapi",


### PR DESCRIPTION
## Summary

This PR improves the release workflow and updates the project's Node.js requirements.

### Key Changes
- **OIDC (Trusted Publisher) Support**: Migrated npm release authentication from static `NPM_TOKEN` to OIDC for better security.
- **Node.js v24 Support**: 
  - Bumped minimum Node.js version in `package.json` (`engines.node`) to `>=24.0.0`.
  - Updated all GitHub Actions workflows (`build.yml`, `release.yml`, `versionUp.yml`) to use Node.js `24.x`.
- **Workflow Reliability**:
  - Removed explicit `ref: main` from checkout steps in `release.yml` and `versionUp.yml` to ensure Actions use the correct tag/branch context during execution.

## Impact
- **Security**: No longer dependent on long-lived npm tokens in GitHub Secrets.
- **Modernization**: Aligned the project with the current Node.js LTS (v24).
- **Correctness**: Fixed an issue where releases were always based on the `main` branch instead of the intended tag.
