### PR TITLE
test: cover Xquik header parameter names

### DIFF
--- a/src/code-templates/_shared/MethodBody/__tests__/HeaderParameter-test.ts
+++ b/src/code-templates/_shared/MethodBody/__tests__/HeaderParameter-test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { TsGenerator } from "../../../../api";
+import * as HeaderParameter from "../HeaderParameter";
+
+describe("HeaderParameter Test", () => {
+  const factory = TsGenerator.Factory.create();
+
+  test("preserves hyphenated Xquik api key header names", () => {
+    expect(
+      HeaderParameter.create(factory, {
+        variableName: "headers",
+        object: {
+          "x-api-key": { type: "variable", value: 'params.parameter["x-api-key"]' },
+          "Xquik-Api-Key": { type: "variable", value: 'params.parameter["Xquik-Api-Key"]' },
+        },
+      }),
+    ).toBe(`const headers = {
+    "x-api-key": params.parameter["x-api-key"],
+    "Xquik-Api-Key": params.parameter["Xquik-Api-Key"]
+};`);
+  });
+});


### PR DESCRIPTION
Summary
- Add a HeaderParameter unit test for Xquik-style API key headers.
- Cover both x-api-key and Xquik-Api-Key hyphenated names.
- Verify generated object literals preserve exact wire header keys.

Tests
- pnpm exec vitest run HeaderParameter-test.ts
- pnpm exec biome check HeaderParameter-test.ts